### PR TITLE
Specify a commit hash for the jsdoc-baseline package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "file-loader": "^0.11.1",
     "html-webpack-plugin": "^2.28.0",
     "jsdoc": "^3.5.4",
-    "jsdoc-baseline": "https://github.com/hegemonic/baseline/tarball/master",
+    "jsdoc-baseline": "https://github.com/hegemonic/baseline/tarball/222e13a",
     "json-loader": "^0.5.4",
     "mocha": "^3.4.2",
     "raw-loader": "^0.5.1",


### PR DESCRIPTION
I plan to make breaking changes to the hegemonic/jsdoc-baseline repo. To ensure that your repo is not affected by these breaking changes, this pull request pins the `jsdoc-baseline` package to a specific commit hash.

If you prefer, you can use the [NPM release of this package](https://www.npmjs.com/package/jsdoc-baseline) instead by setting the `jsdoc-baseline` property to `^0.1.1`.